### PR TITLE
Timestamp bug

### DIFF
--- a/poolmon
+++ b/poolmon
@@ -225,12 +225,12 @@ sub enable_host {
 
 # Append a line to stdout
 sub write_log {
-	printf(STDOUT "%s LOG %s\n", strftime("%h %d %H:%m:%S", localtime()), join('', @_));
+	printf(STDOUT "%s LOG %s\n", strftime("%h %d %H:%M:%S", localtime()), join('', @_));
 }
 
 # Append a line to stderr
 sub write_err {
-	printf(STDERR "%s ERR %s\n", strftime("%h %d %H:%m:%S", localtime()), join('', @_));
+	printf(STDERR "%s ERR %s\n", strftime("%h %d %H:%M:%S", localtime()), join('', @_));
 }
 
 # Check to see if the pidfile exists and the indicated pid is still running


### PR DESCRIPTION
While testing this on my production servers, I noticed the timestamps weren't right.  Turns out the strftime line has %m (which is month) instead of %M (minute).
