### PR TITLE
Disable buffering of stdout when running in foreground mode

### DIFF
--- a/poolmon
+++ b/poolmon
@@ -79,6 +79,11 @@ if (@SSL_PORTS) {
 check_pidfile();
 unless($NOFORK){
     daemonize();
+} else {
+    # Disable buffering of stdout when running in foreground mode
+    my $ofh = select STDOUT;
+    $| = 1;
+    select $ofh;
 }
 
 while(1){


### PR DESCRIPTION
Avoids output delays when poolmon runs in as a systemd service.


Thanks to @h-homma for investigating and reporting this issue.
fixes #9 
